### PR TITLE
Move data.table to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,12 +10,12 @@ Author: Andrea Batch [aut, cre],
 		Walt Kampas [ctb]
 Maintainer: Andrea Batch <Andrea.Batch@bea.gov>
 Depends:
-    R (>= 3.2.1), 
-		data.table
+    R (>= 3.2.1)
 Imports: 
 		httr,
 		DT,
-		jsonlite
+		jsonlite, 
+		data.table
 Description: Provides an R interface for the Bureau of Economic Analysis (BEA) 
 		API (see <http://www.bea.gov/API/bea_web_service_api_user_guide.htm> for 
 		more information) that serves two core purposes - 


### PR DESCRIPTION
Filing this PR by way of a bug report/feature request.

Depends is rarely the right form of dependency; see e.g. https://cran.r-project.org/web/packages/data.table/vignettes/datatable-importing.html and https://github.com/Rdatatable/data.table/issues/3076.

As of now this is likely not complete; let me know if I can help with the migration!